### PR TITLE
made fmtlib a required dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,65 +1,13 @@
-# Created by https://www.gitignore.io/api/c++,cmake
+### build directories ###
+build/
+cmake-build-*/
 
-### C++ ###
-# Prerequisites
-*.d
+### GoogleTest installation ###
+third_party/googletest/*
+!third_party/googletest/CMakeLists.txt.in
 
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
-### CMake ###
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-build
-
-
-### GoogleTest ###
-googletest-build/
-googletest-download/
-googletest-src/
-
-### Docu ###
+### documentation ###
 html/
 
 ### CLion ###
 .idea/
-
-### config.hpp ###
-#config.hpp
-#.codedocs.in
-
-# End of https://www.gitignore.io/api/c++,cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(ENABLE_TESTS "Generate tests" OFF)
 cmake_dependent_option(ENABLE_DEATH_TESTS "Enables gtest's death tests (not support with MPI)" OFF
                        "ENABLE_TESTS" OFF)
 option(GENERATE_DOCUMENTATION "Generate documentation" OFF)
-
+option(ENABLE_STACK_TRACE "Enables the generation of stack traces in the source_location class" ON)
 
 # set assertion level
 set(max_assertion_level 2)
@@ -83,17 +83,22 @@ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
 # set general compiler flags
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # using Clang or GCC
-    message(STATUS "Enabled '-Wall Wextra -pedantic' compiler flags to catch more potential errors")
+    message(STATUS "Enabled '-Wall -Wextra -pedantic' compiler flags to catch more potential errors")
     add_compile_options(-Wall -Wextra -pedantic)
 endif()
 
 # set compiler linker flag for better stack traces
-if (NOT (active_assertion_categories EQUAL 0))
+if (ENABLE_STACK_TRACE)
+    target_compile_definitions(${PROJECT_NAME} INTERFACE ENABLE_STACK_TRACE)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         # using Clang or GCC
-        message(STATUS "Enabled '-rdynamic' linker flag for better stack traces in assertions")
+        message(STATUS "Enabled stack traces using the '-rdynamic' linker flag")
         add_link_options(-rdynamic)
+    else()
+        message(STATUS "Stack traces not supported")
     endif()
+else()
+    message(STATUS "Disabled stack traces")
 endif ()
 
 # set targets to install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if (ENABLE_STACK_TRACE)
         message(STATUS "Enabled stack traces using the '-rdynamic' linker flag")
         add_link_options(-rdynamic)
     else()
-        message(STATUS "Stack traces not supported")
+        message(WARNING "Stack traces not supported")
     endif()
 else()
     message(STATUS "Disabled stack traces")
@@ -155,7 +155,6 @@ endif (ENABLE_TESTS)
 if (ENABLE_DEATH_TESTS)
     message(STATUS "Enabled death tests using gtest's ASSERT_DEATH()")
 endif(ENABLE_DEATH_TESTS)
-
 
 # generate documentation if requested
 if (GENERATE_DOCUMENTATION)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,55 @@
 The MIT License (MIT)
-Copyright © <year> <copyright holders>
+Copyright © 2020 Marcel Breyer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+[**{fmt}**](https://github.com/fmtlib/fmt) license:
+
+Copyright (c) 2012 - present, Victor Zverovich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions of this Software are embedded into a machine-executable object form of such source code, you may redistribute such embedded portions in such object form without including the above copyright and permission notices.
+
+
+[**GTest**](https://github.com/google/googletest) license:
+
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This library provides a small C++ wrapper for MPI libraries (like OpenMPI or MPI
 
 ### Prerequisites
 
-- a C++ compiler supporting C++20 concepts (e.g. [GCC](https://gcc.gnu.org/) trunk (10.0.0))
+- at least [GCC 10.1](https://gcc.gnu.org/gcc-10/)
 - [OpenMPI](https://www.open-mpi.org/) or [MPICH](https://www.mpich.org/) supporting the MPI 3 standard
-- cmake (minimum required 3.5)
+- [CMake](https://cmake.org/) (minimum required 3.5)
+- [{fmt}](https://github.com/fmtlib/fmt) formatting library
 - [Doxygen](http://www.doxygen.nl/) (for documentation only)
-- [fmt formatting library](https://github.com/fmtlib/fmt) (until `std::format` is supported)
 
 ### Installing
 
@@ -41,6 +41,8 @@ Supported configuration options are:
   - `0`: no assertions are active
   - `1`: only precondition assertions are active
   - `2`: additional sanity checks are activated
+  
+- `-DENABLE_STACK_TRACEON/OFF`: enable stack traces for the source location implementation (default: `ON`)
 
 ## Running the tests
 
@@ -63,7 +65,7 @@ To use this library simple add the following lines to your `CMakeLists.txt` file
 ```cmake
 # find the library
 find_package(mpicxx CONFIG REQUIRED)
-find_package(fmt REQUIRED) # until std::format is supported
+find_package(fmt REQUIRED)
 
 # link it against your target
 target_link_libraries(target mpicxx::mpicxx)

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -1,10 +1,10 @@
 ### based on https://github.com/google/googletest/blob/master/googletest/README.md ###
 
 # Download and unpack googletest at configure time
-configure_file(${CMAKE_SOURCE_DIR}/third_party/CMakeLists.txt.in ${CMAKE_SOURCE_DIR}/third_party/googletest-download/CMakeLists.txt)
+configure_file(${CMAKE_SOURCE_DIR}/third_party/googletest/CMakeLists.txt.in ${CMAKE_SOURCE_DIR}/third_party/googletest/download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
     RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/googletest-download )
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/googletest/download )
 
 if(result)
     message(FATAL_ERROR "CMake step for googletest failed: ${result}")
@@ -12,7 +12,7 @@ endif()
 
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
     RESULT_VARIABLE result
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/googletest-download )
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/googletest/download )
 
 if(result)
     message(FATAL_ERROR "Build step for googletest failed: ${result}")
@@ -24,6 +24,6 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Add googletest directly to our build. This defines
 # the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/googletest-src
-                 ${CMAKE_SOURCE_DIR}/third_party/googletest-build
+add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/googletest/src
+                 ${CMAKE_SOURCE_DIR}/third_party/googletest/build
                  EXCLUDE_FROM_ALL)

--- a/include/mpicxx/detail/assert.hpp
+++ b/include/mpicxx/detail/assert.hpp
@@ -1,7 +1,7 @@
 /**
  * @file include/mpicxx/detail/assert.hpp
  * @author Marcel Breyer
- * @date 2020-02-13
+ * @date 2020-05-17
  *
  * @brief Provides more verbose assert alternatives, supporting MPI ranks.
  * @details The asserts are currently separated into three levels:
@@ -22,16 +22,16 @@
  *
  * New assertion syntax and example output:
  * @code
- * MPICXX_ASSERT_PRECONDITION(n > 0, "Parameter can't be negative! : n = %i", n);
+ * MPICXX_ASSERT_PRECONDITION(n >= 0, "Parameter can't be negative!: n = {}", n);
  * // alternative: MPICXX_ASSERT_SANITY
  *
  *
- * Precondition assertion 'n > 0' failed on rank 1
+ * Precondition assertion 'n >= 0' failed on rank 1
  *   in file ./example.cpp
  *   in function 'int test(int)'
  *   @ line 42
  *
- * Parameter can't be negative! : n = -1
+ * Parameter can't be negative!: n = -1
  *
  * stack trace:
  *   #7    ./output.s: test(int) [+0x3]
@@ -46,22 +46,54 @@
  * [*clang*](https://clang.llvm.org/)) is added if and only if the ASSERTION_LEVEL is greater than 0.
  * [*MSVC*](https://visualstudio.microsoft.com/de/vs/features/cplusplus/) currently doesn't print a stack trace at all.
  *
- * In addition the assertions call ``MPI_Abort`` if the assertion is executed within an active MPI environment.
+ * In addition the assertions call `MPI_Abort` if the assertion is executed within an active MPI environment,
+ * [`std::abort`](https://en.cppreference.com/w/cpp/utility/program/abort) otherwise.
  */
 
 #ifndef MPICXX_ASSERT_HPP
 #define MPICXX_ASSERT_HPP
 
-#include <iostream>
-#include <sstream>
+#include <cstdio>
+#include <cstring>
+#include <string>
 #include <utility>
 
 #include <mpi.h>
 #include <fmt/format.h>
+#include <fmt/color.h>
+#include <fmt/ostream.h>
 
 #include <mpicxx/detail/source_location.hpp>
 
 namespace mpicxx::detail {
+
+    /**
+     * @brief Enum class for the different assertion categories.
+     */
+    enum class assertion_category {
+        /** precondition assertion */
+        precondition,
+        /** sanity assertion */
+        sanity
+    };
+    /**
+     * @brief Stream-insertion operator overload for the mpicxx::detail::assertion_category enum class.
+     * @param[inout] out an output stream
+     * @param[in] category the enum class value
+     * @return the output stream
+     */
+    inline std::ostream& operator<<(std::ostream& out, const assertion_category category) {
+        switch (category) {
+            case assertion_category::precondition:
+                out << "PRECONDITION";
+                break;
+            case assertion_category::sanity:
+                out << "SANITY";
+                break;
+        }
+        return out;
+    }
+
     /**
      * @brief This function gets called by the `MPICXX_ASSERT_...` macros and does the actual assertion checking.
      * @details If the assert condition @p cond evaluates to ``false``, the condition, location, custom message and stack trace are printed
@@ -69,40 +101,50 @@ namespace mpicxx::detail {
      * [`std::abort`](https://en.cppreference.com/w/cpp/utility/program/abort) respectively.
      *
      * @tparam Args parameter pack for the placeholder types
-     * @param cond the assert condition, halts the program if evaluated to ``false``
-     * @param cond_str the assert condition as string for a better assert message
-     * @param assertion_category the assertion category (one of: *PRECONDITION*, *SANITY*)
-     * @param loc the location where the assertion appeared
-     * @param msg the custom message printed after the assertion location
-     * @param args the arguments used to fill the ``printf`` like placeholders in the custom message
+     * @param[in] cond the assert condition, aborts the program if evaluated to ``false``
+     * @param[in] cond_str the assert condition as string for a better assert message
+     * @param[in] category the mpicxx::detail::assertion_category
+     * @param[in] loc the location where the assertion appeared
+     * @param[in] msg the custom message printed after the assertion location (using the [**{fmt}**](https://github.com/fmtlib/fmt) syntax)
+     * @param[in] args the arguments used to fill the [**{fmt}**](https://github.com/fmtlib/fmt) placeholders in the custom message
+     *
+     * @calls{
+     * int MPI_Abort(MPI_Comm comm, int errorcode);     // at most once
+     * }
      */
     template <typename... Args>
-    inline void check(const bool cond, const char* cond_str, const char* assertion_category, const source_location& loc,
-            const char* msg, Args&&... args) {
+    inline void check(const bool cond, const char* cond_str, const assertion_category category, const source_location& loc,
+            const char* msg, Args&&... args)
+    {
+        using namespace std::string_literals;
         // check if the assertion holds
         if (!cond) {
-            std::stringstream ss;
-            ss << assertion_category << " assertion '" << cond_str << "' failed";
-            // if we are in an active MPI environment, print current rank
-            if (loc.rank().has_value()) {
-                ss << " on rank " << loc.rank().value();
-            }
-            ss << "\n"
-               << "  in file " << loc.file_name() << "\n"
-               << "  in function '" << loc.function_name() << "'\n"
-               << "  @ line " << loc.line() << "\n\n";
+            fmt::memory_buffer buf;
 
-            // TODO 2020-02-07 22:24 marcel: change from fmt::format to std::format
-            ss << fmt::format(msg, std::forward<Args>(args)...) << "\n\n";
+            // format assertion message
+            auto assertion_color = category == assertion_category::precondition ? fmt::fg(fmt::color::red) : fmt::fg(fmt::rgb(214, 136, 0));
+            fmt::format_to(buf, "{} assertion {} failed {}\n",
+                   fmt::format(assertion_color, "{}", category),
+                   fmt::format(fmt::emphasis::bold | fmt::fg(fmt::color::green), "'{}'", cond_str),
+                   (loc.rank().has_value() ? fmt::format("on rank {}", loc.rank().value()) : "without a running MPI environment"s));
 
-            // write stacktrace into the string stream
-            loc.stack_trace(ss);
+            // format source location
+            fmt::format_to(buf, "  in file {}\n  inf function {}\n  @ line {}\n\n", loc.file_name(), loc.function_name(), loc.line());
 
-            // print whole message at once to prevent race conditions
-            std::cerr << ss.str();
+            // format custom assertion message
+            fmt::format_to(buf, "{}\n\n", fmt::format(fmt::emphasis::bold | fmt::fg(fmt::color::red), msg, std::forward<Args>(args)...));
+
+            // get stack trace
+            fmt::format_to(buf, "{}", loc.stack_trace());
+
+            // print full assertion message
+            using std::to_string;
+            fmt::print(stderr, to_string(buf));
+
 
             // call MPI_Abort only if we are currently in the MPI environment
             // i.e. MPI_Init has already been called, but MPI_Finalize not
+            // TODO 2020-05-17 15:49 marcel: change to mpicxx::running()?
             if (loc.rank().has_value()) {
                 // we are currently in an active MPI environment
                 // -> call MPI_Abort
@@ -131,13 +173,14 @@ namespace mpicxx::detail {
  *
  * An example is to check whether an iterator can be safely dereference or not.
  *
- * @param cond the assert condition
- * @param msg the custom assert message
- * @param ... varying number of parameters to fill the ``printf`` like placeholders in the custom assert message
+ * @param[in] cond the assert condition
+ * @param[in] msg the custom assert message
+ * @param[in] ... varying number of parameters to fill the [**{fmt}**](https://github.com/fmtlib/fmt) placeholders in
+ * the custom assert message
  */
 #if ASSERTION_LEVEL > 0
 #define MPICXX_ASSERT_PRECONDITION(cond, msg, ...) \
-        mpicxx::detail::check(cond, #cond, "Precondition", mpicxx::detail::source_location::current(PRETTY_FUNC_NAME__), msg, ##__VA_ARGS__)
+        mpicxx::detail::check(cond, #cond, mpicxx::detail::assertion_category::precondition, mpicxx::detail::source_location::current(PRETTY_FUNC_NAME__), msg __VA_OPT__(,) __VA_ARGS__)
 #else
 #define MPICXX_ASSERT_PRECONDITION(cond, msg, ...)
 #endif
@@ -151,13 +194,14 @@ namespace mpicxx::detail {
  *
  * An example is the check whether an attempt is made to increment a past-the-end iterator.
  *
- * @param cond the assert condition
- * @param msg the custom assert message
- * @param ... varying number of parameters to fill the ``printf`` like placeholders in the custom assert message
+ * @param[in] cond the assert condition
+ * @param[in] msg the custom assert message
+ * @param[in] ... varying number of parameters to fill the [**{fmt}**](https://github.com/fmtlib/fmt) placeholders in
+ * the custom assert message
  */
 #if ASSERTION_LEVEL > 1
 #define MPICXX_ASSERT_SANITY(cond, msg, ...) \
-        mpicxx::detail::check(cond, #cond, "Sanity", mpicxx::detail::source_location::current(PRETTY_FUNC_NAME__), msg, ##__VA_ARGS__)
+        mpicxx::detail::check(cond, #cond, mpicxx::detail::assertion_category::sanity, mpicxx::detail::source_location::current(PRETTY_FUNC_NAME__), msg __VA_OPT__(,) __VA_ARGS__)
 #else
 #define MPICXX_ASSERT_SANITY(cond, msg, ...)
 #endif

--- a/include/mpicxx/detail/source_location.hpp
+++ b/include/mpicxx/detail/source_location.hpp
@@ -116,8 +116,8 @@ namespace mpicxx::detail {
          * @attention The stack trace report is only available under [*GCC*](https://gcc.gnu.org/) and [*clang*](https://clang.llvm.org/)
          * (to be precise: only if `__GNUG__` is defined). This function does nothing if `__GNUG__` isn't defined.
          */
-        static inline std::string stack_trace(const int max_call_stack_size = 64) {
-#ifdef __GNUG__
+        static inline std::string stack_trace([[maybe_unused]] const int max_call_stack_size = 64) {
+#if defined(ENABLE_STACK_TRACE) && defined(__GNUG__)
             using std::to_string;
             fmt::memory_buffer buf;
             fmt::format_to(buf, "stack trace:\n");
@@ -178,8 +178,12 @@ namespace mpicxx::detail {
                 }
             }
             return fmt::format("{}\n", to_string(buf));
-#else
+#elif defined(ENABLED_STACK_TRACE) && !defined(__GNUG__)
+// stack traces enabled but not supported
             return std::string("No stack trace supported!");
+#else
+// stack traces not supported
+            return std::string{};
 #endif
         }
 

--- a/include/mpicxx/detail/source_location.hpp
+++ b/include/mpicxx/detail/source_location.hpp
@@ -1,7 +1,7 @@
 /**
  * @file include/mpicxx/detail/source_location.hpp
  * @author Marcel Breyer
- * @date 2020-02-18
+ * @date 2020-05-17
  *
  * @brief Provides a `source_location` class similar to [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location).
  * @details Differences are:
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <mpi.h>
+#include <fmt/format.h>
 
 /**
  * @def PRETTY_FUNC_NAME__
@@ -53,13 +54,19 @@ namespace mpicxx::detail {
     public:
         /**
          * @brief Constructs a new source_location with the respective information about the current call side.
-         * @param func the function name (including its signature if supported via the macro `PRETTY_FUNC_NAME__`)
-         * @param file the file name (absolute path)
-         * @param line the line number
-         * @param column the column number
+         * @param[in] func the function name (including its signature if supported via the macro `PRETTY_FUNC_NAME__`)
+         * @param[in] file the file name (absolute path)
+         * @param[in] line the line number
+         * @param[in] column the column number
          * @return the source_location holding the call side location information
          *
          * @attention @p column is always (independent of the call side position) default initialized to 0!
+         *
+         * @calls{
+         * int MPI_Initialized(int *flag);                  // exactly once
+         * int MPI_Finalized(int *flag);                    // exactly once
+         * int MPI_Comm_rank(MPI_Comm comm, int *rank);     // at most once
+         * }
          */
         static source_location current(
                 const std::string_view func = __builtin_FUNCTION(),
@@ -72,14 +79,20 @@ namespace mpicxx::detail {
             loc.func_ = func;
             loc.line_ = line;
             loc.column_ = column;
-            // get the current MPI rank iff the MPI environment is active
-            int is_initialized, is_finalized;
-            MPI_Initialized(&is_initialized);
-            MPI_Finalized(&is_finalized);
-            if (static_cast<bool>(is_initialized) && !static_cast<bool>(is_finalized)) {
-                int rank;
-                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-                loc.rank_ = std::optional<int>(rank);
+            // TODO 2020-05-17 15:49 marcel: change to mpicxx::running()?
+            try {
+                // get the current MPI rank iff the MPI environment is active
+                int is_initialized, is_finalized;
+                MPI_Initialized(&is_initialized);
+                MPI_Finalized(&is_finalized);
+                if (static_cast<bool>(is_initialized) && !static_cast<bool>(is_finalized)) {
+                    int rank;
+                    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+                    loc.rank_ = std::optional<int>(rank);
+                }
+            } catch (...) {
+                // something went wrong during the MPI calls -> no information could be retrieved
+                loc.rank_ = std::nullopt;
             }
             return loc;
         }
@@ -98,15 +111,16 @@ namespace mpicxx::detail {
          *   #2    /lib/x86_64-linux-gnu/libc.so.6: __libc_start_main() [+0xe]
          *   #1    ./output.s: _start() [+0x2]
          * @endcode
-         * @param out the output stream on which the report should be written
-         * @param max_call_stack_size the maximum depth of the stack trace report
+         * @param[in] max_call_stack_size the maximum depth of the stack trace report
          *
          * @attention The stack trace report is only available under [*GCC*](https://gcc.gnu.org/) and [*clang*](https://clang.llvm.org/)
          * (to be precise: only if `__GNUG__` is defined). This function does nothing if `__GNUG__` isn't defined.
          */
-        static inline void stack_trace(std::ostream& out = std::cerr, const int max_call_stack_size = 64) {
+        static inline std::string stack_trace(const int max_call_stack_size = 64) {
 #ifdef __GNUG__
-            out << "stack trace:\n";
+            using std::to_string;
+            fmt::memory_buffer buf;
+            fmt::format_to(buf, "stack trace:\n");
 
             std::vector<std::string> symbols;
             symbols.reserve(max_call_stack_size);
@@ -119,8 +133,7 @@ namespace mpicxx::detail {
 
                 // no stack addresses could be retrieved
                 if (addrlen == 0) {
-                    out << "    <empty, possibly corrupt>" << std::endl;
-                    return;
+                    return fmt::format("{}    <empty, possibly corrupt>\n", to_string(buf));
                 }
 
                 // resolve addresses into symbol strings
@@ -133,8 +146,7 @@ namespace mpicxx::detail {
 
             // iterate over the returned symbol lines -> skip the first and second symbol because they are unimportant
             for (std::size_t i = 2; i < symbols.size(); ++i) {
-                out << "  #" << symbols.size() - i;
-                if (symbols.size() > 9 && symbols.size() - i  < 10) out << " ";
+                fmt::format_to(buf, "  #{:<6}", symbols.size() - i);
 
                 // file_name(function_name+offset) -> split the symbol line accordingly
                 const std::size_t position1 = std::min(symbols[i].find_first_of("("), symbols[i].size());
@@ -154,18 +166,20 @@ namespace mpicxx::detail {
 
                     if (status == 0) {
                         // demangling successful -> print pretty function name
-                        out << "    " << file_name << ": " << function_name_demangled << " [" << function_offset << "]\n";
+                        fmt::format_to(buf, "{}: {} [{}]\n", file_name, function_name_demangled, function_offset);
                     } else {
                         // demangling failed -> print un-demangled function name
-                        out << "    " << file_name << ": " << function_name << "() [" << function_offset << "]\n";
+                        fmt::format_to(buf, "{}: {}() [{}]\n", file_name, function_name, function_offset);
                     }
                     free(function_name_demangled);
                 } else {
                     // print complete symbol line if the splitting went wrong
-                    out << "    " << symbols[i] << "\n";
+                    fmt::format_to(buf, "{}\n", symbols[i]);
                 }
             }
-            out << std::endl;
+            return fmt::format("{}\n", to_string(buf));
+#else
+            return std::string("No stack trace supported!");
 #endif
         }
 
@@ -198,7 +212,7 @@ namespace mpicxx::detail {
          * [`std::optional`](https://en.cppreference.com/w/cpp/utility/optional) is empty.
          * @return a `std::optional<int>` containing the current rank
          */
-        constexpr std::optional<int> rank() const noexcept { return rank_; };
+        constexpr std::optional<int> rank() const noexcept { return rank_; }
 
     private:
         std::string file_ = "unknown";

--- a/include/mpicxx/info/info.hpp
+++ b/include/mpicxx/info/info.hpp
@@ -1,7 +1,7 @@
 /**
  * @file include/mpicxx/info/info.hpp
  * @author Marcel Breyer
- * @date 2020-04-12
+ * @date 2020-05-17
  *
  * @brief Implements a wrapper class around the *MPI_Info* object.
  * @details The @ref mpicxx::info class interface is inspired by the
@@ -1615,7 +1615,6 @@ namespace mpicxx {
             // check whether the key exists
             if (!this->key_exists(key)) {
                 // key doesn't exist
-                // TODO 2020-02-14 20:32 marcel: change from fmt::format to std::format
                 throw std::out_of_range(fmt::format("{} doesn't exist!", std::forward<decltype(key)>(key)));
             }
             // create proxy object and forward key
@@ -1661,7 +1660,6 @@ namespace mpicxx {
             // check whether the key exists
             if (!static_cast<bool>(flag)) {
                 // key doesn't exist
-                // TODO 2020-02-14 20:32 marcel: change from fmt::format to std::format
                 throw std::out_of_range(fmt::format("{} doesn't exist!", std::forward<decltype(key)>(key)));
             }
             // get the value associated with key

--- a/test/detail/source_location.cpp
+++ b/test/detail/source_location.cpp
@@ -67,13 +67,16 @@ TEST(DetailTest, SourceStackTrace) {
 
     std::string trace = loc.stack_trace();
 
-#ifdef __GNUG__
+#if defined(ENABLE_STACK_TRACE) && defined(__GNUG__)
     // stack trace should be present
     EXPECT_FALSE(trace.empty());
-#else
+#elif defined(ENABLED_STACK_TRACE) && !defined(__GNUG__)
+    // no stack trace supported
     using namespace std::string_literals;
-    // no stack trace  supported
-    EXPECT_EQ(ss.str(), "No stack trace supported!"s);
+    EXPECT_EQ(trace, "No stack trace supported!"s)
+#else
+    // no stack trace requested
+    EXPECT_TRUE(trace.empty());
 #endif
 
 }

--- a/test/detail/source_location.cpp
+++ b/test/detail/source_location.cpp
@@ -1,7 +1,7 @@
 /**
  * @file test/detail/source_location.cpp
  * @author Marcel Breyer
- * @date 2020-02-08
+ * @date 2020-05-17
  *
  * @brief Test cases for the @ref mpicxx::detail::source_location implementation.
  * @details Testsuite: *DetailTest*
@@ -65,15 +65,15 @@ TEST(DetailTest, CurrentSourceLocationPrettyFuncName) {
 TEST(DetailTest, SourceStackTrace) {
     mpicxx::detail::source_location loc = mpicxx::detail::source_location::current();
 
-    std::stringstream ss;
-    loc.stack_trace(ss);
+    std::string trace = loc.stack_trace();
 
 #ifdef __GNUG__
     // stack trace should be present
-    EXPECT_FALSE(ss.str().empty());
+    EXPECT_FALSE(trace.empty());
 #else
+    using namespace std::string_literals;
     // no stack trace  supported
-    EXPECT_TRUE(ss.str().empty());
+    EXPECT_EQ(ss.str(), "No stack trace supported!"s);
 #endif
 
 }

--- a/third_party/googletest/CMakeLists.txt.in
+++ b/third_party/googletest/CMakeLists.txt.in
@@ -8,8 +8,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           master
-  SOURCE_DIR        "${CMAKE_SOURCE_DIR}/third_party/googletest-src"
-  BINARY_DIR        "${CMAKE_SOURCE_DIR}/third_party/googletest-build"
+  SOURCE_DIR        "${CMAKE_SOURCE_DIR}/third_party/googletest/src"
+  BINARY_DIR        "${CMAKE_SOURCE_DIR}/third_party/googletest/build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""


### PR DESCRIPTION
- assertions are know formatted using fmtlib (including coloring)
- stack traces are now optional and can be toggled using ENABLE_STACK_TRACE as cmake option
- updated LICENSE.md
- better GoogleTest installation